### PR TITLE
fix individual player orientation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 .DS_Store
 *.log
+pnpm-lock.yaml
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ node_modules
 dist
 .DS_Store
 *.log
-pnpm-lock.yaml
 
+worker/.wrangler

--- a/web/src/multiplayer/OnlineGameManager.tsx
+++ b/web/src/multiplayer/OnlineGameManager.tsx
@@ -21,7 +21,8 @@ interface GameState {
   p2PlaceIndex: number;
   p1Ready: boolean;
   p2Ready: boolean;
-  orientation: Orientation;
+  p1Orientation: Orientation;
+  p2Orientation: Orientation;
   winner: 1 | 2 | null;
   names: { [key: number]: string };
   log: Array<{ type: string; player?: number; [key: string]: any }>;
@@ -155,7 +156,7 @@ export default function OnlineGameManager({ onBack, initialPlayerName }: OnlineG
       player: myPlayer,
       start: c,
       size: nextSize,
-      orientation: gameState.orientation
+      orientation: myPlayer === 1 ? gameState.p1Orientation : gameState.p2Orientation
     });
   }, [myPlayer, gameState, connectionState.status, sendAction]);
 
@@ -184,8 +185,9 @@ export default function OnlineGameManager({ onBack, initialPlayerName }: OnlineG
     const amIReady = myPlayer === 1 ? gameState.p1Ready : gameState.p2Ready;
     if (amIReady) return; // Already ready, no more changes
 
-    // Toggle orientation in shared game state
-    const newOrientation = gameState.orientation === 'H' ? 'V' : 'H';
+    // Toggle orientation for this player only
+    const currentOrientation = myPlayer === 1 ? gameState.p1Orientation : gameState.p2Orientation;
+    const newOrientation = currentOrientation === 'H' ? 'V' : 'H';
     sendAction({
       type: 'setOrientation',
       player: myPlayer,
@@ -220,8 +222,9 @@ export default function OnlineGameManager({ onBack, initialPlayerName }: OnlineG
       return;
     }
 
-    const coords = coordsFor(c, nextSize, gameState.orientation);
-    const valid = canPlace(currentPlayer.fleet, c, nextSize, gameState.orientation);
+    const currentOrientation = myPlayer === 1 ? gameState.p1Orientation : gameState.p2Orientation;
+    const coords = coordsFor(c, nextSize, currentOrientation);
+    const valid = canPlace(currentPlayer.fleet, c, nextSize, currentOrientation);
     setPreview({ coords, valid });
   }, [myPlayer, gameState, connectionState.status]);
 
@@ -412,7 +415,7 @@ export default function OnlineGameManager({ onBack, initialPlayerName }: OnlineG
               const placeIndex = myPlayer === 1 ? gameState.p1PlaceIndex : gameState.p2PlaceIndex;
               return [5, 4, 3, 3, 2, 2][placeIndex] as ShipSize | undefined;
             })() : undefined}
-            orientation={gameState.orientation}
+            orientation={myPlayer === 1 ? gameState.p1Orientation : gameState.p2Orientation}
             onRotate={handleOrientationToggle}
             onPlace={handlePlace}
             onHover={handleHover}

--- a/web/src/multiplayer/SpectatorGameManager.tsx
+++ b/web/src/multiplayer/SpectatorGameManager.tsx
@@ -13,7 +13,8 @@ interface GameState {
   p2PlaceIndex: number;
   p1Ready: boolean;
   p2Ready: boolean;
-  orientation: string;
+  p1Orientation: string;
+  p2Orientation: string;
   winner: 1 | 2 | null;
   names: { [key: number]: string };
   log: Array<{ type: string; player?: number; [key: string]: any }>;

--- a/worker/src/game-room.ts
+++ b/worker/src/game-room.ts
@@ -8,7 +8,8 @@ interface GameState {
   p2PlaceIndex: number;
   p1Ready: boolean;
   p2Ready: boolean;
-  orientation: Orientation;
+  p1Orientation: Orientation;
+  p2Orientation: Orientation;
   winner: 1 | 2 | null;
   names: { [key: number]: string };
   log: Array<{ type: string; player?: number; [key: string]: any }>;
@@ -426,8 +427,12 @@ export class GameRoom implements DurableObject {
       }
 
       case 'setOrientation': {
-        const { orientation } = payload;
-        newState.orientation = orientation;
+        const { player, orientation } = payload;
+        if (player === 1) {
+          newState.p1Orientation = orientation;
+        } else {
+          newState.p2Orientation = orientation;
+        }
         break;
       }
 
@@ -470,7 +475,8 @@ export class GameRoom implements DurableObject {
       p2PlaceIndex: 0,
       p1Ready: false,
       p2Ready: false,
-      orientation: 'H',
+      p1Orientation: 'H',
+      p2Orientation: 'H',
       winner: null,
       names: {},
       log: []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Each player can independently choose ship placement orientation in online matches.
  - Orientation toggle now affects only your own placement and actions.
  - Placement previews and controls respect your chosen orientation.
  - Spectators now see per-player orientations correctly.

- Chores
  - Updated project ignore rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->